### PR TITLE
Make WithOverride feature thread-safe

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -3,12 +3,11 @@ package dotenv
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/joho/godotenv"
 )
 
-const maxStackLen = 5
+const maxStackLen = 20
 
 // Load loads the environment.
 func Load() error {
@@ -22,39 +21,7 @@ func Load() error {
 		return nil
 	}
 
-	var pc [maxStackLen]uintptr
-	n := runtime.Callers(1, pc[:])
-
-	override := false
-
-	for i := 0; i < n; i++ {
-		f := runtime.FuncForPC(pc[i])
-
-		if f.Name() == withOverridePackagePath {
-			override = true
-
-			break
-		}
-	}
-
-	if !override {
-		return godotenv.Overload(file)
-	}
-
-	tuples, err := godotenv.Read(file)
-	if err != nil {
-		return err
-	}
-
-	for k, v := range tuples {
-		if _, defined := os.LookupEnv(k); !defined {
-			if sErr := os.Setenv(k, v); sErr != nil {
-				return nil
-			}
-		}
-	}
-
-	return nil
+	return godotenv.Overload(file)
 }
 
 func findDotEnv(dir string) string {

--- a/override.go
+++ b/override.go
@@ -1,13 +1,19 @@
 package dotenv
 
 import (
-	"os"
+	"fmt"
 	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 type empty struct{}
 
 var withOverridePackagePath = reflect.TypeOf(empty{}).PkgPath() + ".WithOverride"
+
+var overrideStack = sync.Map{}
 
 // WithOverride overrides the environment variables with the given ones
 // and restores them after the callback is executed.
@@ -28,6 +34,9 @@ func WithOverride(callback func(), kv ...string) {
 		panic("dotenv.WithOverride requires an even number of arguments")
 	}
 
+	pc := make([]uintptr, 1)
+	runtime.Callers(2, pc)
+
 	tuples := make(map[string]string, len(kv)/2)
 
 	for i := 0; i < len(kv); i += 2 {
@@ -37,35 +46,59 @@ func WithOverride(callback func(), kv ...string) {
 		tuples[k] = v
 	}
 
-	original := make(map[string]string)
-	unset := make(map[string]struct{})
+	key := fmt.Sprintf("%d:%d:%s", goid(), pc[0], runtime.FuncForPC(pc[0]).Name())
 
-	for k, v := range tuples {
-		originalValue, defined := os.LookupEnv(k)
-		if defined {
-			original[k] = originalValue
-		}
-
-		if !defined {
-			unset[k] = empty{}
-		}
-
-		if err := os.Setenv(k, v); err != nil {
-			panic(err)
-		}
-	}
-
+	overrideStack.Store(key, tuples)
 	callback()
+	overrideStack.Delete(key)
+}
 
-	for k, v := range original {
-		if err := os.Setenv(k, v); err != nil {
-			panic(err)
+func isOverridden() (map[string]string, bool) {
+	var pc [maxStackLen]uintptr
+
+	n := runtime.Callers(2, pc[:])
+	override := false
+	tuples := make(map[string]string)
+
+	for i := 0; i < n; i++ {
+		f := runtime.FuncForPC(pc[i])
+		if f == nil {
+			continue
+		}
+
+		if f.Name() == withOverridePackagePath {
+			override = true
+			overrider := runtime.FuncForPC(pc[i+1])
+
+			if overrider != nil {
+				key := fmt.Sprintf("%d:%d:%s", goid(), pc[i+1], overrider.Name())
+				found, ok := overrideStack.Load(key)
+
+				if ok {
+					pairs, validType := found.(map[string]string)
+					if validType {
+						tuples = pairs
+					}
+				}
+			}
+
+			break
 		}
 	}
 
-	for k := range unset {
-		if err := os.Unsetenv(k); err != nil {
-			panic(err)
-		}
+	return tuples, override
+}
+
+func goid() int {
+	var buf [64]byte
+
+	n := runtime.Stack(buf[:], false)
+	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
+	id, err := strconv.Atoi(idField)
+
+	if err != nil {
+		return 0
 	}
+
+	return id
 }

--- a/override_parallel_test.go
+++ b/override_parallel_test.go
@@ -1,0 +1,150 @@
+package dotenv_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/tangelo-labs/go-dotenv"
+)
+
+func Test_Override1(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override2(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override3(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override4(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override5(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override6(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override7(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override8(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override9(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override10(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override11(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override12(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override13(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override14(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override15(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override16(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override17(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override18(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override19(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func Test_Override20(t *testing.T) {
+	t.Parallel()
+
+	testOverride(t)
+}
+
+func testOverride(t *testing.T) {
+	gofakeit := gofakeit.New(time.Now().Unix())
+	val := gofakeit.Sentence(10)
+
+	dotenv.WithOverride(func() {
+		var env tEnv
+
+		if err := dotenv.LoadAndParse(&env); err != nil {
+			t.Errorf("failed to load env: %s", err)
+		}
+
+		if env.ConcurrentValue != val {
+			t.Errorf("expected %s, got %s", val, env.ConcurrentValue)
+		}
+	}, "CONCURRENT_STRING", val)
+}
+
+type tEnv struct {
+	ConcurrentValue string `env:"CONCURRENT_STRING" default:"bar"`
+}

--- a/override_test.go
+++ b/override_test.go
@@ -1,14 +1,12 @@
 package dotenv_test
 
 import (
-	"fmt"
-	"math/rand"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tangelo-labs/go-dotenv"
 )
@@ -97,33 +95,38 @@ func TestWithOverride(t *testing.T) {
 	t.Run("GIVEN an environment variable", func(t *testing.T) {
 		require.NoError(t, os.Setenv("GIT_GUT", "lol"))
 
-		t.Run("WHEN multiple goroutines are overriding THEN each goroutine should be its value", func(t *testing.T) {
-			muxAssert := sync.Mutex{}
+		t.Run("WHEN multiple goroutines are overriding the same variable THEN each goroutine should see its own overriden value", func(t *testing.T) {
 			wg := sync.WaitGroup{}
+			ng := 100
 
-			for i := 0; i < 100; i++ {
+			faker := gofakeit.New(time.Now().Unix())
+			ready := make(chan struct{})
 
-			}
-
-			for i := 0; i < 100; i++ {
+			for i := 0; i < ng; i++ {
 				wg.Add(1)
+
 				go func(idx int) {
-					val := fmt.Sprintf("%d", rand.New(rand.NewSource(int64(idx))).Int63())
-					fmt.Printf("val %d: %s\n", idx, val)
+					defer wg.Done()
+
+					value := faker.LoremIpsumSentence(5)
 
 					dotenv.WithOverride(func() {
-						defer wg.Done()
-						var env loneVarTestEnv
-						err := dotenv.LoadAndParse(&env)
+						var env testEnv
 
-						muxAssert.Lock()
-						assert.NoErrorf(t, err, "error on idx %d", idx)
-						assert.EqualValuesf(t, val, env.YRURunning, "assert fail on idx %d", idx)
-						muxAssert.Unlock()
-					}, "GIT_GUT", val)
+						<-ready
+
+						if err := dotenv.LoadAndParse(&env); err != nil {
+							t.Errorf("failed to load env: %s", err)
+						}
+
+						if env.ConcurrentString != value {
+							t.Errorf("expected %s, got %s", value, env.ConcurrentString)
+						}
+					}, "CONCURRENT_STRING", value)
 				}(i)
 			}
 
+			close(ready)
 			wg.Wait()
 		})
 	})
@@ -133,8 +136,5 @@ type testEnv struct {
 	Foo                                      string   `env:"FOO" default:"bar"`
 	TheMeaningOfLifeTheUniverseAndEverything int      `env:"DUMMY" default:"42"`
 	FakeList                                 []string `env:"FAKE_LIST" default:"foo,bar" delimiter:","`
-}
-
-type loneVarTestEnv struct {
-	YRURunning string `env:"GIT_GUT"`
+	ConcurrentString                         string   `env:"CONCURRENT_STRING" default:"foo"`
 }

--- a/override_test.go
+++ b/override_test.go
@@ -1,9 +1,14 @@
 package dotenv_test
 
 import (
+	"fmt"
+	"math/rand"
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tangelo-labs/go-dotenv"
 )
@@ -88,10 +93,48 @@ func TestWithOverride(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("GIVEN an environment variable", func(t *testing.T) {
+		require.NoError(t, os.Setenv("GIT_GUT", "lol"))
+
+		t.Run("WHEN multiple goroutines are overriding THEN each goroutine should be its value", func(t *testing.T) {
+			muxAssert := sync.Mutex{}
+			wg := sync.WaitGroup{}
+
+			for i := 0; i < 100; i++ {
+
+			}
+
+			for i := 0; i < 100; i++ {
+				wg.Add(1)
+				go func(idx int) {
+					val := fmt.Sprintf("%d", rand.New(rand.NewSource(int64(idx))).Int63())
+					fmt.Printf("val %d: %s\n", idx, val)
+
+					dotenv.WithOverride(func() {
+						defer wg.Done()
+						var env loneVarTestEnv
+						err := dotenv.LoadAndParse(&env)
+
+						muxAssert.Lock()
+						assert.NoErrorf(t, err, "error on idx %d", idx)
+						assert.EqualValuesf(t, val, env.YRURunning, "assert fail on idx %d", idx)
+						muxAssert.Unlock()
+					}, "GIT_GUT", val)
+				}(i)
+			}
+
+			wg.Wait()
+		})
+	})
 }
 
 type testEnv struct {
 	Foo                                      string   `env:"FOO" default:"bar"`
 	TheMeaningOfLifeTheUniverseAndEverything int      `env:"DUMMY" default:"42"`
 	FakeList                                 []string `env:"FAKE_LIST" default:"foo,bar" delimiter:","`
+}
+
+type loneVarTestEnv struct {
+	YRURunning string `env:"GIT_GUT"`
 }

--- a/override_test.go
+++ b/override_test.go
@@ -95,7 +95,7 @@ func TestWithOverride(t *testing.T) {
 	t.Run("GIVEN an environment variable", func(t *testing.T) {
 		require.NoError(t, os.Setenv("GIT_GUT", "lol"))
 
-		t.Run("WHEN multiple goroutines are overriding the same variable THEN each goroutine should see its own overriden value", func(t *testing.T) {
+		t.Run("WHEN multiple goroutines are overriding the same variable THEN each goroutine should see its own overridden value", func(t *testing.T) {
 			wg := sync.WaitGroup{}
 			ng := 100
 

--- a/parse.go
+++ b/parse.go
@@ -257,6 +257,12 @@ func valueForField(field reflect.Value, value value, tags *structtag.Tags, varNa
 
 // lookup similar to Get but returns whether the variable is present or not.
 func lookup(name string, def ...string) (value, bool) {
+	if tuples, overridden := isOverridden(); overridden {
+		if v, ok := tuples[name]; ok {
+			return value(v), true
+		}
+	}
+
 	d := ""
 	if len(def) > 0 {
 		d = def[0]


### PR DESCRIPTION
Currently `WithOverride` method is not thread-safe and callback is execute while other threads are calling or called `os.SetEnv()`. // TODO