### PR TITLE
Increase override call-stack size

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -7,8 +7,6 @@ import (
 	"github.com/joho/godotenv"
 )
 
-const maxStackLen = 20
-
 // Load loads the environment.
 func Load() error {
 	cwd, err := os.Getwd()

--- a/override.go
+++ b/override.go
@@ -16,8 +16,11 @@ const maxStackLen = 500
 type packageMarker struct{}
 
 var (
+	// withOverridePackagePath is the package path of the WithOverride function.
 	withOverridePackagePath = reflect.TypeOf(packageMarker{}).PkgPath() + ".WithOverride"
-	overrideStack           = sync.Map{}
+
+	// overrideStack is a stack that holds the overridden environment variables indexed by goroutine ID.
+	overrideStack = sync.Map{}
 )
 
 // WithOverride overrides the environment variables with the given ones

--- a/override.go
+++ b/override.go
@@ -9,16 +9,21 @@ import (
 	"sync"
 )
 
-type empty struct{}
+// maxStackLen is the maximum number of stack frames to inspect for the WithOverride call.
+const maxStackLen = 500
 
-var withOverridePackagePath = reflect.TypeOf(empty{}).PkgPath() + ".WithOverride"
+// packageMarker is a marker type to get the package path of the WithOverride function.
+type packageMarker struct{}
 
-var overrideStack = sync.Map{}
+var (
+	withOverridePackagePath = reflect.TypeOf(packageMarker{}).PkgPath() + ".WithOverride"
+	overrideStack           = sync.Map{}
+)
 
 // WithOverride overrides the environment variables with the given ones
 // and restores them after the callback is executed.
 //
-// Any call to the Load, LoadAndParse or similar within the callback will be
+// Any call to the Parse, LoadAndParse or similar within the callback will be
 // affected by the overridden values.
 //
 // This function will panic if the number of arguments is not even, or if there is
@@ -53,7 +58,8 @@ func WithOverride(callback func(), kv ...string) {
 	overrideStack.Delete(key)
 }
 
-func isOverridden() (map[string]string, bool) {
+// isOverriddenCall checks if the current execution context is within a WithOverride call.
+func isOverriddenCall() (map[string]string, bool) {
 	var pc [maxStackLen]uintptr
 
 	n := runtime.Callers(2, pc[:])
@@ -89,6 +95,7 @@ func isOverridden() (map[string]string, bool) {
 	return tuples, override
 }
 
+// goid returns the goroutine ID of the current goroutine.
 func goid() int {
 	var buf [64]byte
 

--- a/parse.go
+++ b/parse.go
@@ -272,7 +272,7 @@ func valueForField(field reflect.Value, value value, tags *structtag.Tags, varNa
 
 // lookup similar to Get but returns whether the variable is present or not.
 func lookup(name string, def ...string) (value, bool) {
-	if tuples, overridden := isOverridden(); overridden {
+	if tuples, overridden := isOverriddenCall(); overridden {
 		if v, ok := tuples[name]; ok {
 			return value(v), true
 		}


### PR DESCRIPTION
Increase the call stack size during inspection.
Most escenarios where WithOverride are test-related code,  in those cases a stack size of 20 may be too low, increasing to 500.